### PR TITLE
Fix/#23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# mcMMO - fix/#23
-このリポジトリは Nekozouneko Server Issue #23の暫定対応パッチです。  
-https://github.com/TeamNekozouneko/NekozounekoServer/issues/23  
-当サーバー向けに改造されたものであるため、これを使用して発生した損害等について当サーバーは一切責任を負いかねます。  
+# mcMMO
 The #1 RPG Mod for Minecraft
 
 ## Useful URLs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# mcMMO
+# mcMMO - fix/#23
+このリポジトリは Nekozouneko Server Issue #23の暫定対応パッチです。  
+https://github.com/TeamNekozouneko/NekozounekoServer/issues/23  
+当サーバー向けに改造されたものであるため、これを使用して発生した損害等について当サーバーは一切責任を負いかねます。  
 The #1 RPG Mod for Minecraft
 
 ## Useful URLs

--- a/src/main/java/com/gmail/nossr50/listeners/InventoryListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/InventoryListener.java
@@ -49,7 +49,7 @@ public class InventoryListener implements Listener {
         BlockState furnaceState = furnaceBlock.getState();
         ItemStack smelting = furnaceState instanceof Furnace ? ((Furnace) furnaceState).getInventory().getSmelting() : null;
 
-        if (!ItemUtils.isSmeltable(smelting)) {
+        if (!ItemUtils.isSmeltable(smelting) || event.getBurnTime() <= 0) {
             return;
         }
 

--- a/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
+++ b/src/main/java/com/gmail/nossr50/skills/smelting/SmeltingManager.java
@@ -33,6 +33,7 @@ public class SmeltingManager extends SkillManager {
      * @param burnTime The initial burn time from the {@link FurnaceBurnEvent}
      */
     public int fuelEfficiency(int burnTime) {
+        if (burnTime <= 0) return 0;
         return Math.min(Short.MAX_VALUE, Math.max(1, burnTime * getFuelEfficiencyMultiplier()));
     }
 


### PR DESCRIPTION
https://github.com/TeamNekozouneko/NekozounekoServer/issues/23

原因：バケツのburnTimeが0にもかかわらず、燃料のMultiplier処理で0が入ると1が返ってくるため。
（event.setBurnTimeメソッドで1が設定されるため、内部的にバケツが燃焼できると処理されてしまう）

[FIX] fuelEfficiencyメソッドにおいてburnTimeが0以下の時は、そのまま0を返す
[FIX] onFurnaceBurnEventメソッドにおいてburnTimeが0以下の時は、EXP獲得処理を実施しないように